### PR TITLE
remove lastPendingTimestamp as required field in status

### DIFF
--- a/charts/internal/shoot-cert-management-shoot/templates/crds.yaml
+++ b/charts/internal/shoot-cert-management-shoot/templates/crds.yaml
@@ -146,7 +146,6 @@ spec:
               description: State is the certificate state.
               type: string
           required:
-            - lastPendingTimestamp
             - state
           type: object
       required:


### PR DESCRIPTION
**What this PR does / why we need it**:
fix for certificate crd validation. The field `lastPendingTimestamp` in the status is not required. This prevents creating new certificates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
validation: remove lastPendingTimestamp as required field in status
```
