### PR TITLE
Remove lastPendingTimestamp from CRD

### DIFF
--- a/charts/internal/shoot-cert-management-shoot/templates/crds.yaml
+++ b/charts/internal/shoot-cert-management-shoot/templates/crds.yaml
@@ -130,11 +130,6 @@ spec:
                 - name
                 - namespace
               type: object
-            lastPendingTimestamp:
-              description: LastPendingTimestamp contains the start timestamp of the
-                last pending status.
-              format: date-time
-              type: string
             message:
               description: Message is the status or error message.
               type: string


### PR DESCRIPTION
/area robustness
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR removes the `status.lastPendingTimestamp` from the certificate CR to workaround this status update issue: https://github.com/gardener/cert-management/issues/31.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue has been fixed which caused certificates to not get ready if the TLS certificate was successfully issued before.
```
