### PR TITLE
Fix nil pointer when spec.providerConfig=nil

### DIFF
--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -325,17 +325,20 @@ func (a *actuator) createManagedResource(ctx context.Context, namespace, name, c
 
 func (a *actuator) updateStatus(ctx context.Context, ex *extensionsv1alpha1.Extension, certConfig *service.CertConfig) error {
 	var resources []gardencorev1beta1.NamedResourceReference
-	for _, issuerConfig := range certConfig.Issuers {
-		name := "extension-shoot-cert-service-issuer-" + issuerConfig.Name
-		resources = append(resources, gardencorev1beta1.NamedResourceReference{
-			Name: name,
-			ResourceRef: autoscalingv1.CrossVersionObjectReference{
-				Kind:       "Secret",
-				Name:       name,
-				APIVersion: "v1",
-			},
-		})
+	if certConfig != nil {
+		for _, issuerConfig := range certConfig.Issuers {
+			name := "extension-shoot-cert-service-issuer-" + issuerConfig.Name
+			resources = append(resources, gardencorev1beta1.NamedResourceReference{
+				Name: name,
+				ResourceRef: autoscalingv1.CrossVersionObjectReference{
+					Kind:       "Secret",
+					Name:       name,
+					APIVersion: "v1",
+				},
+			})
+		}
 	}
+
 	return controller.TryUpdateStatus(ctx, retry.DefaultBackoff, a.client, ex, func() error {
 		ex.Status.Resources = resources
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the shoot-cert-service panics when the Extension `spec.providerConfig=nil`:
```
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1835ec0, 0x2a0ff70)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1835ec0, 0x2a0ff70)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller.(*actuator).updateStatus(0xc0004b70e0, 0x1caff00, 0xc000c98d40, 0xc0007e49c0, 0x0, 0xc000c52240, 0x18)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller/actuator.go:328 +0x3a
github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller.(*actuator).Reconcile(0xc0004b70e0, 0x1caff00, 0xc000c98d40, 0xc0007e49c0, 0x1a385ca, 0x9)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller/actuator.go:102 +0x1aa
github.com/gardener/gardener/extensions/pkg/controller/extension.(*reconciler).reconcile(0xc000800fc0, 0x1caff00, 0xc000c98d40, 0xc0007e49c0, 0x1a385ca, 0x9, 0xc00bed9180, 0x0, 0x0, 0x0)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/github.com/gardener/gardener/extensions/pkg/controller/extension/reconciler.go:213 +0x152
github.com/gardener/gardener/extensions/pkg/controller/extension.(*reconciler).Reconcile(0xc000800fc0, 0xc000795f00, 0x18, 0xc000795ee0, 0x12, 0x0, 0x12, 0x1c77800, 0xc0007e44e0)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/github.com/gardener/gardener/extensions/pkg/controller/extension/reconciler.go:197 +0x44e
github.com/gardener/gardener/extensions/pkg/controller.(*operationAnnotationWrapper).Reconcile(0xc000c98cc0, 0xc000795f00, 0x18, 0xc000795ee0, 0x12, 0x0, 0xbfb9e0878ad3db1a, 0xc0005d2091, 0xc000d1e758)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/github.com/gardener/gardener/extensions/pkg/controller/reconciler.go:89 +0x283
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004b7220, 0x1895980, 0xc00b312ae0, 0x0)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:245 +0x161
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004b7220, 0x36900000000)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:221 +0xae
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0004b7220)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:200 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000659440)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000659440, 0x3b9aca00, 0x0, 0x1, 0xc0005ae240)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000659440, 0x3b9aca00, 0xc0005ae240)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:182 +0x526
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1686b8a]

goroutine 376 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x105
panic(0x1835ec0, 0x2a0ff70)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller.(*actuator).updateStatus(0xc0004b70e0, 0x1caff00, 0xc000c98d40, 0xc0007e49c0, 0x0, 0xc000c52240, 0x18)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller/actuator.go:328 +0x3a
github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller.(*actuator).Reconcile(0xc0004b70e0, 0x1caff00, 0xc000c98d40, 0xc0007e49c0, 0x1a385ca, 0x9)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller/actuator.go:102 +0x1aa
github.com/gardener/gardener/extensions/pkg/controller/extension.(*reconciler).reconcile(0xc000800fc0, 0x1caff00, 0xc000c98d40, 0xc0007e49c0, 0x1a385ca, 0x9, 0xc00bed9180, 0x0, 0x0, 0x0)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/github.com/gardener/gardener/extensions/pkg/controller/extension/reconciler.go:213 +0x152
github.com/gardener/gardener/extensions/pkg/controller/extension.(*reconciler).Reconcile(0xc000800fc0, 0xc000795f00, 0x18, 0xc000795ee0, 0x12, 0x0, 0x12, 0x1c77800, 0xc0007e44e0)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/github.com/gardener/gardener/extensions/pkg/controller/extension/reconciler.go:197 +0x44e
github.com/gardener/gardener/extensions/pkg/controller.(*operationAnnotationWrapper).Reconcile(0xc000c98cc0, 0xc000795f00, 0x18, 0xc000795ee0, 0x12, 0x0, 0xbfb9e0878ad3db1a, 0xc0005d2091, 0xc000d1e758)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/github.com/gardener/gardener/extensions/pkg/controller/reconciler.go:89 +0x283
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004b7220, 0x1895980, 0xc00b312ae0, 0x0)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:245 +0x161
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004b7220, 0x36900000000)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:221 +0xae
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0004b7220)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:200 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000659440)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000659440, 0x3b9aca00, 0x0, 0x1, 0xc0005ae240)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000659440, 0x3b9aca00, 0xc0005ae240)
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/go/src/github.com/gardener/gardener-extension-shoot-cert-service/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:182 +0x526
runtime: note: your Linux kernel may be buggy
runtime: note: see https://golang.org/wiki/LinuxKernelSignalVectorBug
runtime: note: mlock workaround for kernel bug failed with errno 12
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing shoot-cert-service to crash when the Extension `spec.providerConfig=nil` is now fixed.
```
