### PR TITLE
Fix cert-controller-manager leader election

### DIFF
--- a/charts/internal/shoot-cert-management-seed/templates/deployment.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
           readOnly: true
         args:
         - --name={{ include "cert-management.fullname" . }}
+        - --namespace=kube-system
         - --source=/etc/shoot-cluster/kubeconfig
         - --issuer.issuer-namespace={{ .Release.Namespace }}
         - --issuer.default-issuer={{ .Values.defaultIssuer.name }}

--- a/charts/internal/shoot-cert-management-shoot/templates/cert-management-role.yaml
+++ b/charts/internal/shoot-cert-management-shoot/templates/cert-management-role.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: extensions.gardener.cloud:extension-shoot-cert-service:cert-controller-manager
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]

--- a/charts/internal/shoot-cert-management-shoot/templates/cert-management-rolebinding.yaml
+++ b/charts/internal/shoot-cert-management-shoot/templates/cert-management-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extensions.gardener.cloud:extension-shoot-cert-service:cert-controller-manager
+  namespace: {{ .Release.Namespace }}
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: gardener.cloud:system:cert-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extensions.gardener.cloud:extension-shoot-cert-service:cert-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently cert-controller-manager fails to acquire leadership because of missing RBAC:


```
E0709 14:52:43.176146       1 leaderelection.go:330] error retrieving resource lock shoot--foo--bar/cert-controller-manager: configmaps "cert-controller-manager" is forbidden: User "gardener.cloud:system:cert-management" cannot get resource "configmaps" in API group "" in the namespace "shoot--foo--bar"
E0709 14:52:45.445372       1 leaderelection.go:330] error retrieving resource lock shoot--foo--bar/cert-controller-manager: configmaps "cert-controller-manager" is forbidden: User "gardener.cloud:system:cert-management" cannot get resource "configmaps" in API group "" in the namespace "shoot--foo--bar"
```

This PR adds the missing RBAC.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I couldn't configure it with the leader election done in the default cluster as stated in the cert-management README.md (not sure even whether it is possible currently)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing `cert-controller-manager` to acquire leadership is now fixed.
```
