### PR TITLE
Add permissions for leader election lease of cert-controller-manager in control plane

### DIFF
--- a/charts/internal/shoot-cert-management-seed/templates/deployment.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/deployment.yaml
@@ -81,6 +81,7 @@ spec:
         {{- if .Values.shootIssuers.enabled }}
         - --allow-target-issuers
         {{- end }}
+        - --lease-name=shoot-cert-service
         {{- range $idx, $flag := .Values.additionalConfiguration }}
         - {{ $flag }}
         {{- end }}

--- a/charts/internal/shoot-cert-management-shoot/templates/cert-management-role.yaml
+++ b/charts/internal/shoot-cert-management-shoot/templates/cert-management-role.yaml
@@ -5,6 +5,35 @@ metadata:
   name: extensions.gardener.cloud:extension-shoot-cert-service:cert-controller-manager
   namespace: {{ .Release.Namespace }}
 rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - watch
+      - update
+    resourceNames:
+      - shoot-cert-service
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - shoot-cert-service
+    verbs:
+      - get
+      - watch
+      - update


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt

**What this PR does / why we need it**:
Add permissions for using leases in the `cert-controller-manager` running the control plane.
With PR https://github.com/gardener/cert-management/pull/79, the next version v0.7.1 will use both configmaps and leases.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add permissions for leader election lease of cert-controller-manager in control plane
```
