### PR TITLE
ACME providers on private network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM eu.gcr.io/gardener-project/3rd/golang:1.17.5 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.17.6 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-cert-service
 COPY . .

--- a/charts/internal/shoot-cert-management-seed/templates/deployment.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-private-networks: allowed
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.gardener.cloud/to-seed-apiserver: allowed

--- a/docs/usage/request_cert.md
+++ b/docs/usage/request_cert.md
@@ -155,6 +155,9 @@ data:
 ### Issuer
 Another prerequisite to request certificates for custom domains is a dedicated issuer.
 
+Note: This is only needed if the default issuer provided by Gardener is restricted to shoot related domains or you are using
+domain names not visible to public DNS servers. You may therefore try first without defining an own issuer.
+
 The custom issuers are specified normally in the shoot manifest.
 
 If the `shootIssuers` feature is enabled, it can alternatively be defined in the shoot cluster.
@@ -179,6 +182,9 @@ spec:
           privateKeySecretName: my-privatekey # referenced resource, the private key must be stored in the secret at `data.privateKey`
       #shootIssuers:
       #  enabled: true # if true, allows to specify issuers in the shoot cluster
+
+      #precheckNameservers: "10.0.0.53,10.123.56.53,8.8.8.8" # optional comma separated list of DNS server IP addresses if public DNS servers are not sufficient for prechecking DNS challenges
+
   resources:
   - name: my-privatekey
     resourceRef:
@@ -186,6 +192,11 @@ spec:
       kind: Secret
       name: custom-issuer-privatekey # name of secret in Gardener project
 ```
+
+If you are using an ACME provider for private domains, you may need to change the nameservers used for
+checking the availability of the DNS challenge's TXT record before the certificate is requested from the ACME provider.
+By default, only public DNS servers may be used for this purpose.
+At least one of the `precheckNameservers` must be able to resolve the private domain names. 
 
 ####
 

--- a/example/30-extension.yaml
+++ b/example/30-extension.yaml
@@ -33,3 +33,5 @@ spec:
       # dnsClass: foo
     #shootIssuers: # optionally overwrite global service configuration for issuers on shoot cluster
     #  enabled: false
+
+    #precheckNameservers: "10.0.0.53,10.123.56.53,8.8.8.8" # optional comma separated list of DNS server IP addresses if public DNS servers are not sufficient for prechecking DNS challenges

--- a/hack/api-reference/service.md
+++ b/hack/api-reference/service.md
@@ -85,6 +85,19 @@ ShootIssuers
 If specified, it overwrites the ShootIssuers settings of the service configuration.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>precheckNameservers</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PrecheckNameservers is used to specify a comma-separated list of DNS servers for checking availability for DNS
+challenge before calling ACME CA</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="service.cert.extensions.gardener.cloud/v1alpha1.ACMEExternalAccountBinding">ACMEExternalAccountBinding

--- a/pkg/apis/config/validation/validation.go
+++ b/pkg/apis/config/validation/validation.go
@@ -56,12 +56,13 @@ func validateACME(acme *config.ACME, fldPath *field.Path) field.ErrorList {
 
 	if acme.PrecheckNameservers != nil {
 		servers := strings.Split(*acme.PrecheckNameservers, ",")
-		if len(servers) == 0 {
+		if len(servers) == 1 && len(servers[0]) == 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, "must contain at least one DNS server IP"))
-		}
-		for i, server := range servers {
-			if net.ParseIP(server) == nil {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, fmt.Sprintf("invalid IP for %d. DNS server", i+1)))
+		} else {
+			for i, server := range servers {
+				if net.ParseIP(server) == nil {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, fmt.Sprintf("invalid IP for %d. DNS server", i+1)))
+				}
 			}
 		}
 	}

--- a/pkg/apis/service/types.go
+++ b/pkg/apis/service/types.go
@@ -34,6 +34,10 @@ type CertConfig struct {
 	// ShootIssuers contains enablement for issuers on shoot cluster
 	// If specified, it overwrites the ShootIssuers settings of the service configuration.
 	ShootIssuers *ShootIssuers
+
+	// PrecheckNameservers is used to specify a comma-separated list of DNS servers for checking availability for DNS
+	// challenge before calling ACME CA
+	PrecheckNameservers *string
 }
 
 // IssuerConfig contains information for certificate issuers.

--- a/pkg/apis/service/v1alpha1/types.go
+++ b/pkg/apis/service/v1alpha1/types.go
@@ -69,6 +69,11 @@ type CertConfig struct {
 	// If specified, it overwrites the ShootIssuers settings of the service configuration.
 	// +optional
 	ShootIssuers *ShootIssuers `json:"shootIssuers,omitempty"`
+
+	// PrecheckNameservers is used to specify a comma-separated list of DNS servers for checking availability for DNS
+	// challenge before calling ACME CA
+	// +optional
+	PrecheckNameservers *string `json:"precheckNameservers,omitempty"`
 }
 
 // IssuerConfig contains information for certificate issuers.

--- a/pkg/apis/service/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/service/v1alpha1/zz_generated.conversion.go
@@ -125,6 +125,7 @@ func autoConvert_v1alpha1_CertConfig_To_service_CertConfig(in *CertConfig, out *
 	out.Issuers = *(*[]service.IssuerConfig)(unsafe.Pointer(&in.Issuers))
 	out.DNSChallengeOnShoot = (*service.DNSChallengeOnShoot)(unsafe.Pointer(in.DNSChallengeOnShoot))
 	out.ShootIssuers = (*service.ShootIssuers)(unsafe.Pointer(in.ShootIssuers))
+	out.PrecheckNameservers = (*string)(unsafe.Pointer(in.PrecheckNameservers))
 	return nil
 }
 
@@ -137,6 +138,7 @@ func autoConvert_service_CertConfig_To_v1alpha1_CertConfig(in *service.CertConfi
 	out.Issuers = *(*[]IssuerConfig)(unsafe.Pointer(&in.Issuers))
 	out.DNSChallengeOnShoot = (*DNSChallengeOnShoot)(unsafe.Pointer(in.DNSChallengeOnShoot))
 	out.ShootIssuers = (*ShootIssuers)(unsafe.Pointer(in.ShootIssuers))
+	out.PrecheckNameservers = (*string)(unsafe.Pointer(in.PrecheckNameservers))
 	return nil
 }
 

--- a/pkg/apis/service/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/service/v1alpha1/zz_generated.deepcopy.go
@@ -62,6 +62,11 @@ func (in *CertConfig) DeepCopyInto(out *CertConfig) {
 		*out = new(ShootIssuers)
 		**out = **in
 	}
+	if in.PrecheckNameservers != nil {
+		in, out := &in.PrecheckNameservers, &out.PrecheckNameservers
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/service/zz_generated.deepcopy.go
+++ b/pkg/apis/service/zz_generated.deepcopy.go
@@ -62,6 +62,11 @@ func (in *CertConfig) DeepCopyInto(out *CertConfig) {
 		*out = new(ShootIssuers)
 		**out = **in
 	}
+	if in.PrecheckNameservers != nil {
+		in, out := &in.PrecheckNameservers, &out.PrecheckNameservers
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Support ACME providers on private network and allow to specify `precheckNameservers` in the `providerConfig` of the extension.

**Which issue(s) this PR fixes**:
Fixes #107


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Allow access to ACME CA on private network.
```
