### PR TITLE
Add permissions to create events in control plane

### DIFF
--- a/charts/internal/shoot-cert-management-seed/templates/rbac.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/rbac.yaml
@@ -54,6 +54,7 @@ rules:
     - "*"
 - apiGroups:
     - ""
+    - events.k8s.io
   resources:
     - events
   verbs:

--- a/charts/internal/shoot-cert-management-seed/templates/rbac.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/rbac.yaml
@@ -52,6 +52,13 @@ rules:
     - "secrets"
   verbs:
     - "*"
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Permissions have been missing to create events if issuer creation fails.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Add permissions to create events in control plane if issuer creation fails.
```
