### PR TITLE
Update limits limit. Disable limit autoscaling.

### DIFF
--- a/charts/internal/shoot-cert-management-seed/templates/vpa.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/vpa.yaml
@@ -14,6 +14,7 @@ spec:
   resourcePolicy:
     containerPolicies:
       - containerName: '*'
+        controlledValues: RequestsOnly
         minAllowed:
           cpu: 10m
           memory: 20Mi

--- a/charts/internal/shoot-cert-management-seed/values.yaml
+++ b/charts/internal/shoot-cert-management-seed/values.yaml
@@ -18,8 +18,7 @@ resources:
    cpu: 100m
    memory: 128Mi
   limits:
-   cpu: 200m
-   memory: 384Mi
+   memory: 600Mi
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
/area auto-scaling
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Sets absolute memory limit for the shoot-cert-management-seed container per measured actual usage. Removes CPU limit of same container. Disables limit autoscaling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
A fixed memory limit was set for the shoot-cert-management-seed container, in accordance with measurements of actual field usage. CPU limit of same container was removed.
```
