### PR TITLE
Update builder image to golang:1.19.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -15,7 +15,8 @@ gardener-extension-shoot-cert-service:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          retention_policy: 'clean-snapshots'
         draft_release: ~
         options:
           public_build_logs: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.19.2 AS builder
+FROM golang:1.19.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-cert-service
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Update builder image to golang:1.19.5

Enable clean-snapshots

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update builder image to golang:1.19.5
```
