### PR TITLE
Add secretLabels section to certificates CRD

### DIFF
--- a/charts/internal/shoot-cert-management-shoot/templates/crds-v1.yaml
+++ b/charts/internal/shoot-cert-management-shoot/templates/crds-v1.yaml
@@ -171,6 +171,11 @@ spec:
                 renew:
                   description: Renew triggers a renewal if set to true
                   type: boolean
+                secretLabels:
+                  additionalProperties:
+                    type: string
+                  description: SecretLabels are labels to add to the certificate secret.
+                  type: object
                 secretName:
                   description: SecretName is the name of the secret object to use for
                     storing the certificate.
@@ -188,6 +193,7 @@ spec:
                         name must be unique.
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
               type: object
             status:
               description: CertificateStatus is the status of the certificate request.
@@ -223,8 +229,8 @@ spec:
                     description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
                     \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
                     // +listType=map // +listMapKey=type Conditions []metav1.Condition
                     `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"

--- a/docs/usage/request_cert.md
+++ b/docs/usage/request_cert.md
@@ -63,7 +63,8 @@ metadata:
     dns.gardener.cloud/ttl: "600"
     #cert.gardener.cloud/commonname: "*.example.com" # optional, if not specified the first name from spec.tls[].hosts is used as common name
     #cert.gardener.cloud/dnsnames: "" # optional, if not specified the names from spec.tls[].hosts are used
-    #cert.gardener.cloud/follow-cname: "true" # optional, same as spec.followCNAME in certificates    
+    #cert.gardener.cloud/follow-cname: "true" # optional, same as spec.followCNAME in certificates
+    #cert.gardener.cloud/secret-labels: "key1=value1,key2=value2" # optional labels for the certificate secret
 spec:
   tls:
   - hosts:
@@ -99,7 +100,8 @@ metadata:
     dns.gardener.cloud/ttl: "600"
     cert.gardener.cloud/commonname: "*.example.example.com"
     cert.gardener.cloud/dnsnames: ""
-    #cert.gardener.cloud/follow-cname: "true" # optional, same as spec.followCNAME in certificates    
+    #cert.gardener.cloud/follow-cname: "true" # optional, same as spec.followCNAME in certificates
+    #cert.gardener.cloud/secret-labels: "key1=value1,key2=value2" # optional labels for the certificate secret
   name: test-service
   namespace: default
 spec:
@@ -133,6 +135,10 @@ spec:
   # the DNS challenge will be written to '_acme-challenge.writable.domain.com'.
   #followCNAME: true
 
+  # optionally set labels for the secret
+  #secretLabels:
+  #  key1: value1
+  #  key2: value2
 ```
 
 ## Supported attributes
@@ -147,6 +153,7 @@ Here is a list of all supported annotations regarding the certificate extension:
 | `spec.issuerRef.name` | `cert.gardener.cloud/issuer:`      | E.g. `gardener`                                         | No                                              | Specifies the issuer you want to use. Only necessary if you request certificates for [custom domains](#Custom-Domains).                                                                                        |
 | N/A                   | `cert.gardener.cloud/revoked:`     | `true` otherwise always false                           | No                                              | Use only to revoke a certificate, see [reference](#references) for more details                                                                                                                                |
 | `spec.followCNAME`    | `cert.gardener.cloud/follow-cname` | E.g. `true`                                             | No                                              | Specifies that the usage of a delegated domain for DNS challenges is allowed. Details see [Follow CNAME](https://github.com/gardener/cert-management#follow-cname).                                            |
+| `spec.secretLabels`   | `cert.gardener.cloud/secret-labels`| for annotation use e.g. `key1=value1,key2=value2`       | No                                              | Specifies labels for the certificate secret.                                                                                                                                                                   |
 
 ## Request a wildcard certificate
 In order to avoid the creation of multiples certificates for every single endpoints, you may want to create a wildcard certificate for your shoot's default cluster.

--- a/docs/usage/request_default_domain_cert.md
+++ b/docs/usage/request_default_domain_cert.md
@@ -48,6 +48,8 @@ metadata:
   annotations:
     cert.gardener.cloud/purpose: managed
     #cert.gardener.cloud/issuer: custom-issuer
+    #cert.gardener.cloud/follow-cname: "true" # optional, same as spec.followCNAME in certificates
+    #cert.gardener.cloud/secret-labels: "key1=value1,key2=value2" # optional labels for the certificate secret
 spec:
   tls:
   - hosts:
@@ -81,6 +83,8 @@ metadata:
     dns.gardener.cloud/dnsnames: "service.shoot.project.default-domain.gardener.cloud" 
     dns.gardener.cloud/ttl: "600"
     #cert.gardener.cloud/issuer: custom-issuer
+    #cert.gardener.cloud/follow-cname: "true" # optional, same as spec.followCNAME in certificates
+    #cert.gardener.cloud/secret-labels: "key1=value1,key2=value2" # optional labels for the certificate secret
   name: test-service
   namespace: default
 spec:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
**What this PR does / why we need it**:
cert-management version 0.10.3 introduced the section `secretLabels` for certificates. CRD and docu are updated accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
