### PR TITLE
add certificate expiration alert

### DIFF
--- a/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
@@ -44,8 +44,8 @@ data:
             type: seed
             visibility: operator
           annotations:
-            description: Certificate in namespace {{ .Release.Namespace }} will be expired in {{ .Values.configuration.certExpirationAlertDays }} days.
-            summary: SSL certificate will expire in {{ .Values.configuration.certExpirationAlertDays }} days
+            description: Certificate in namespace {{ .Release.Namespace }} will be expired less than {{ .Values.configuration.certExpirationAlertDays }} days.
+            summary: SSL certificate will expire less than {{ .Values.configuration.certExpirationAlertDays }} days
 
   dashboard_operators: |
     cert-controller-manager-dashboard.json: |-

--- a/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
@@ -36,16 +36,16 @@ data:
       - name: cert-controller-manager.rules
         rules:
         - alert: SslCertificateWillExpireSoon
-          expr:  (cert_management_cert_object_expire-time())/86400 <= 3
+          expr:  (cert_management_cert_object_expire-time())/86400 <= {{ .Values.configuration.certExpirationAlertDays }}
           for: 30m
           labels:
             service: cert-controller-manager
             severity: critical
             type: seed
-            visibility: all
+            visibility: operator
           annotations:
-            description: Certificate in namespace {{ .Release.Namespace }} will be expired in 3 days.
-            summary: SSL certificate will expire in 3 days
+            description: Certificate in namespace {{ .Release.Namespace }} will be expired in {{ .Values.configuration.certExpirationAlertDays }} days.
+            summary: SSL certificate will expire in {{ .Values.configuration.certExpirationAlertDays }} days
 
   dashboard_operators: |
     cert-controller-manager-dashboard.json: |-

--- a/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
@@ -30,6 +30,23 @@ data:
         regex: ^(cert_management_.+)$
         action: keep
 
+  alerting_rules: |
+    cert-controller-manager.rules.yaml: |
+      groups:
+      - name: cert-controller-manager.rules
+        rules:
+        - alert: SslCertificateWillExpireSoon
+          expr:  (cert_management_cert_object_expire-time())/86400 <= 3
+          for: 30m
+          labels:
+            service: cert-controller-manager
+            severity: critical
+            type: seed
+            visibility: all
+          annotations:
+            description: Certificate in namespace {{ .Release.Namespace }} will be expired in 3 days.
+            summary: SSL certificate will expire in 3 days
+
   dashboard_operators: |
     cert-controller-manager-dashboard.json: |-
 {{- .Files.Get "cert-dashboard.json" | nindent 6 }}

--- a/charts/internal/shoot-cert-management-seed/values.yaml
+++ b/charts/internal/shoot-cert-management-seed/values.yaml
@@ -76,6 +76,7 @@ configuration:
 #   ...
 #   -----END CERTIFICATE-----
   deactivateAuthorizations: true
+  certExpirationAlertDays: 15
 
 additionalConfiguration:
 - --kubeconfig.disable-deploy-crds


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
New metrics "cert_management_cert_object_expire" added, based on the new metrics adding alert to monitor the certificate object expiration date, if less than 3 days, sending emails to operator and users. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
