### PR TITLE
No alerting for certificates in error state

### DIFF
--- a/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
@@ -37,7 +37,7 @@ data:
       - name: cert-controller-manager.rules
         rules:
         - alert: SslCertificateWillExpireSoon
-          expr: cert_management_cert_object_expire > 0 and (cert_management_cert_object_expire-time())/86400 <= {{ .Values.configuration.certExpirationAlertDays }}
+          expr: ((cert_management_cert_object_expire > 0) - time()) / 86400 <= {{ .Values.configuration.certExpirationAlertDays }}
           for: 30m
           labels:
             service: cert-controller-manager

--- a/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
@@ -37,7 +37,7 @@ data:
       - name: cert-controller-manager.rules
         rules:
         - alert: SslCertificateWillExpireSoon
-          expr:  (cert_management_cert_object_expire-time())/86400 <= {{ .Values.configuration.certExpirationAlertDays }}
+          expr: cert_management_cert_object_expire > 0 and (cert_management_cert_object_expire-time())/86400 <= {{ .Values.configuration.certExpirationAlertDays }}
           for: 30m
           labels:
             service: cert-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
If a cluster contains misconfigured certificates, the metrics `cert_management_cert_object_expire` reports a value of 0 and the alerting is triggered as the certificate seems to have expired since about 19600 days.

To exclude such false alerts, the expression has been adapted. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
No alerting for certificates in error state
```
