### PR TITLE
Add promhttp_metric_handler_requests_total to the available metrics

### DIFF
--- a/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
@@ -31,7 +31,7 @@ data:
         regex: ^(cert_management_.+)$
         action: keep
       - source_labels: [ __name__, code ]
-        regex: ^(promhttp_metric_handler_requests_total);(200|500|503)$
+        regex: ^(promhttp_metric_handler_requests_total);(200|500|503|400|404)$
         target_label: __name__
         replacement: cert_controller_manager_$1
 {{- if gt .Values.configuration.certExpirationAlertDays 0.0 }}

--- a/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/configmap-observability.yaml
@@ -30,7 +30,10 @@ data:
       - source_labels: [ __name__ ]
         regex: ^(cert_management_.+)$
         action: keep
-
+      - source_labels: [ __name__, code ]
+        regex: ^(promhttp_metric_handler_requests_total);(200|500|503)$
+        target_label: __name__
+        replacement: cert_controller_manager_$1
 {{- if gt .Values.configuration.certExpirationAlertDays 0.0 }}
   alerting_rules: |
     cert-controller-manager.rules.yaml: |

--- a/charts/internal/shoot-cert-management-seed/templates/servicemonitor.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/servicemonitor.yaml
@@ -21,5 +21,9 @@ spec:
       - __name__
       action: keep
       regex: ^(cert_management_.+)$
+    - sourceLabels: [ __name__, code ]
+      regex: ^(promhttp_metric_handler_requests_total);(200|500|503|400|404)$
+      target_label: __name__
+      replacement: cert_controller_manager_$1
   honorLabels: false
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring

**What this PR does / why we need it**:
I need this PR to capture the certificate controller manager metrics in each seed and later propagate those metrics into the long-term Prometheus. This will allow the Argus team and me to create new monitoring dashboards.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I might be missing something here, let me know If I need to change more file
**Release note**:

```other operator
Add promhttp_metric_handler_requests_total to the available metrics
```
