### PR TITLE
[release-v1.44] Automated cherry pick of #286: Remove memory limit from the cert-controller-manager Deployment

### DIFF
--- a/charts/internal/shoot-cert-management-seed/values.yaml
+++ b/charts/internal/shoot-cert-management-seed/values.yaml
@@ -15,10 +15,8 @@ genericTokenKubeconfigSecretName: generic-token-kubeconfig
 
 resources:
   requests:
-   cpu: 100m
-   memory: 128Mi
-  limits:
-   memory: 600Mi
+    cpu: 100m
+    memory: 128Mi
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
/kind bug
/area auto-scaling

Cherry pick of #286 on release-v1.44.

#286: Remove memory limit from the cert-controller-manager Deployment

**Release Notes:**
```other operator
The memory limit from the `cert-controller-manager` Deployment is now removed.
```