### PR TITLE
Add SAST logs to OCM component descriptor

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -12,6 +12,16 @@ gardener-extension-shoot-cert-service:
         attribute: image.tag
 
   base_definition:
+    repo:
+      source_labels:
+      - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+        value:
+          policy: skip
+          comment: |
+            we use gosec for sast scanning. See attached log.
+    steps:
+      verify:
+        image: 'golang:1.23.2'
     traits:
       version:
         preprocess: 'inject-commit-hash'
@@ -55,6 +65,17 @@ gardener-extension-shoot-cert-service:
           nextversion: 'bump_minor'
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+          assets:
+          - type: build-step-log
+            step_name: verify
+            purposes:
+            - lint
+            - sast
+            - gosec
+            comment: |
+                we use gosec (linter) for SAST scans
+                see: https://github.com/securego/gosec
+                enabled by https://github.com/gardener/gardener-extension-shoot-cert-service/pull/302
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add SAST logs to OCM component descriptor

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
