### PR TITLE
Improve resource utilization of cert-management controller

### DIFF
--- a/charts/internal/shoot-cert-management-seed/templates/vpa.yaml
+++ b/charts/internal/shoot-cert-management-seed/templates/vpa.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -10,10 +10,11 @@ spec:
     kind: Deployment
     name: {{ include "cert-management.fullname" . }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: {{ .Values.vpa.updatePolicy.updateMode }}
   resourcePolicy:
     containerPolicies:
       - containerName: '*'
         controlledValues: RequestsOnly
         minAllowed:
-          memory: 20Mi
+          memory: {{ .Values.vpa.minAllowed.memory }}
+{{- end }}

--- a/charts/internal/shoot-cert-management-seed/values.yaml
+++ b/charts/internal/shoot-cert-management-seed/values.yaml
@@ -15,8 +15,8 @@ genericTokenKubeconfigSecretName: generic-token-kubeconfig
 
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 5m
+    memory: 30Mi
 
 nodeSelector: {}
 tolerations: []
@@ -84,6 +84,13 @@ additionalConfiguration:
 - --kubeconfig.disable-deploy-crds
 - --source.disable-deploy-crds
 - --target.disable-deploy-crds
+
+vpa:
+  enabled: true
+  minAllowed:
+    memory: 20Mi
+  updatePolicy:
+    updateMode: "Auto"
 
 # TODO(rfranzke): Remove this field after August 2024.
 gep19Monitoring: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Reduce default values for resource utilisation of shoot-dns-service controller in the control plane.
Additionally, its VPA is made optional for consistency reasons.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reduce default values for resource utilisation of cert-management controller in the control plane.
```
