### PR TITLE
chore: Remove obsolete Make target adjust-install-gosec.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,18 +93,12 @@ generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(MOCKGEN) $(Y
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./test
 
-# TODO(martinweindel): Remove once https://github.com/gardener/gardener/pull/10642 is available as release.
-TOOLS_PKG_PATH := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools 2>/dev/null)
-.PHONY: adjust-install-gosec.sh
-adjust-install-gosec.sh:
-	@chmod +xw $(TOOLS_PKG_PATH)/install-gosec.sh
-
 .PHONY: sast
-sast: adjust-install-gosec.sh $(GOSEC)
+sast: $(GOSEC)
 	@./hack/sast.sh
 
 .PHONY: sast-report
-sast-report: adjust-install-gosec.sh $(GOSEC)
+sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
 
 .PHONY: test


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

Removes the obsolete Make target `adjust-install-gosec.sh` as the PR referenced by the `TODO` is available as of [`gardener/gardener@v1.106.0`](https://github.com/gardener/gardener/pull/10642).

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
