### PR TITLE
Drop redundant check step

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,6 +19,7 @@ gardener-extension-shoot-cert-service:
           policy: skip
           comment: |
             we use gosec for sast scanning. See attached log.
+    steps: {}
     traits:
       version:
         preprocess: 'inject-commit-hash'

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -68,7 +68,7 @@ gardener-extension-shoot-cert-service:
           release_callback: '.ci/prepare_release'
           assets:
           - type: build-step-log
-            step_name: pull-extension-shoot-cert-service-unit
+            step_name: verify
             purposes:
             - lint
             - sast

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,9 +19,6 @@ gardener-extension-shoot-cert-service:
           policy: skip
           comment: |
             we use gosec for sast scanning. See attached log.
-    steps:
-      verify:
-        image: golang:1.24
     traits:
       version:
         preprocess: 'inject-commit-hash'
@@ -71,7 +68,7 @@ gardener-extension-shoot-cert-service:
           release_callback: '.ci/prepare_release'
           assets:
           - type: build-step-log
-            step_name: verify
+            step_name: pull-extension-shoot-cert-service-unit
             purposes:
             - lint
             - sast

--- a/.ci/verify
+++ b/.ci/verify
@@ -1,13 +1,4 @@
 #!/bin/bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
-cd "$(dirname $0)/.."
-
-git config --global user.email "gardener@sap.com"
-git config --global user.name "Gardener CI/CD"
-
-export GOTOOLCHAIN=auto
-make verify-extended
+# TODO(martinweindel): remove this script once the CI pipeline is updated
+echo "obsolete"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind task

**What this PR does / why we need it**:
Drop redundant check step, as it is now executed by Prow check job `pull-extension-shoot-cert-service-unit`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
