### PR TITLE
Set resources for shoot deployment

### DIFF
--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -253,6 +253,7 @@ func (a *actuator) createValues(
 			return nil, err
 		}
 		values.GenericTokenKubeconfigSecretName = extensions.GenericTokenKubeconfigSecretNameFromCluster(cluster)
+		values.Resources = cluster.Shoot.Spec.Resources
 	} else {
 		if err := setValuesForGardenOrSeed(ex, &values); err != nil {
 			return nil, err

--- a/pkg/controller/extension/deployer.go
+++ b/pkg/controller/extension/deployer.go
@@ -7,7 +7,7 @@ package extension
 import (
 	"strings"
 
-	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"k8s.io/utils/ptr"
 
@@ -25,7 +25,7 @@ type Values struct {
 	Image                            string
 	GenericTokenKubeconfigSecretName string
 	RestrictedDomains                string
-	Resources                        []core.NamedResourceReference
+	Resources                        []gardencorev1beta1.NamedResourceReference
 
 	ShootDeployment  bool
 	GardenDeployment bool

--- a/pkg/controller/extension/deployer_test.go
+++ b/pkg/controller/extension/deployer_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
-	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -1211,7 +1211,7 @@ var _ = Describe("deployer", func() {
 					Email:  "bar2@example.com",
 				},
 			}
-			values.Resources = []core.NamedResourceReference{
+			values.Resources = []gardencorev1beta1.NamedResourceReference{
 				{Name: "bar-secret", ResourceRef: autoscalingv1.CrossVersionObjectReference{Name: "original-bar-secret", Kind: "Secret"}},
 				{Name: "eab-secret", ResourceRef: autoscalingv1.CrossVersionObjectReference{Name: "original-bar-secret", Kind: "Secret"}},
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The refactoring in PR #357 introduced a regression bug. The resources from the cluster are not set for shoot deployments. 
As a consequence, if a custom issuer with a `privateKeySecretName` is defined in the shoot manifest, the referenced secret is not found anymore.
It reports an error like
```
Error reconciling Extension: failed to lookup referenced private key secret for issuer <issuer>: invalid referenced resource: <name>
```
This PR provides a fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix lookup of referenced secret for custom issuer in shoot manifest with `privateKeySecretName` specified.
```
