### PR TITLE
Update `resources` section of example operator extension

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -88,10 +88,21 @@ spec:
             # typically the same values as at .spec.deployment.values.certificateConfig.defaultIssuer
             ...
   resources:
-  - globallyEnabled: true # if true, the extension is enabled for all shoots by default
+  - autoEnable:
+    - shoot # if set, the extension is enabled for all shoots by default
+    clusterCompatibility:
+    - shoot
     kind: Extension
     type: shoot-cert-service
     workerlessSupported: true
+  - clusterCompatibility:
+    - garden
+    - seed
+    kind: Extension
+    lifecycle:
+      delete: AfterKubeAPIServer
+      reconcile: BeforeKubeAPIServer
+    type: controlplane-cert-service
 ```
 
 #### Providing Trusted TLS Certificate for Garden Runtime Cluster
@@ -224,15 +235,19 @@ kind: ControllerRegistration
 
 #### Enablement
 
-If the `shoot-cert-service` should be enabled for every shoot cluster in your Gardener managed environment, you need to globally enable it in the `ControllerRegistration`:
+If the `shoot-cert-service` should be enabled for every shoot cluster in your Gardener managed environment, you need to auto enable it in the `ControllerRegistration`:
 ```yaml
 apiVersion: core.gardener.cloud/v1beta1
 kind: ControllerRegistration
 ...
   resources:
-  - globallyEnabled: true
-    kind: Extension
+  - kind: Extension
     type: shoot-cert-service
+    autoEnable:
+    - shoot # if set, the extension is enabled for all shoots by default
+    clusterCompatibility:
+    - shoot
+    workerlessSupported: true
 ```
 
 Alternatively, you're given the option to only enable the service for certain shoots:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Update `resources` section of example operator extension to include `clusterCompatibility` and `autoEnable` to reflect last changes in Gardener.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Missed to update in #415 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```docu operator
Update `resources` section of example operator extension to include `clusterCompatibility` and `autoEnable`
```
