### PR TITLE
Add annotation `cert.gardener.cloud/class` for control plane issuers

### DIFF
--- a/pkg/controller/extension/shared/deployer_issuers.go
+++ b/pkg/controller/extension/shared/deployer_issuers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
+	"github.com/gardener/cert-management/pkg/cert/source"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +166,13 @@ func (d *Deployer) createIssuer(input Issuer) *certv1alpha1.Issuer {
 			ACME: d.createACMESpec(input),
 			CA:   d.createCASpec(input),
 		},
+	}
+	if !d.values.ShootDeployment {
+		class := "seed"
+		if d.values.GardenDeployment {
+			class = "garden"
+		}
+		issuer.Annotations = map[string]string{source.AnnotClass: class}
 	}
 	if input.RequestsPerDayQuota > 0 {
 		issuer.Spec.RequestsPerDayQuota = &input.RequestsPerDayQuota

--- a/pkg/controller/extension/shared/deployer_issuers.go
+++ b/pkg/controller/extension/shared/deployer_issuers.go
@@ -167,12 +167,8 @@ func (d *Deployer) createIssuer(input Issuer) *certv1alpha1.Issuer {
 			CA:   d.createCASpec(input),
 		},
 	}
-	if !d.values.ShootDeployment {
-		class := "seed"
-		if d.values.GardenDeployment {
-			class = "garden"
-		}
-		issuer.Annotations = map[string]string{source.AnnotClass: class}
+	if d.values.CertClass != "" {
+		issuer.Annotations = map[string]string{source.AnnotClass: d.values.CertClass}
 	}
 	if input.RequestsPerDayQuota > 0 {
 		issuer.Spec.RequestsPerDayQuota = &input.RequestsPerDayQuota

--- a/pkg/controller/extension/shared/deployer_test.go
+++ b/pkg/controller/extension/shared/deployer_test.go
@@ -1289,6 +1289,9 @@ var _ = Describe("Deployer", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "garden",
 						Namespace: values.Namespace,
+						Annotations: map[string]string{
+							"cert.gardener.cloud/class": "garden",
+						},
 					},
 					Spec: certv1alpha1.IssuerSpec{
 						CA: &certv1alpha1.CASpec{
@@ -1352,6 +1355,9 @@ var _ = Describe("Deployer", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "garden",
 						Namespace: values.Namespace,
+						Annotations: map[string]string{
+							"cert.gardener.cloud/class": "seed",
+						},
 					},
 					Spec: certv1alpha1.IssuerSpec{
 						ACME: &certv1alpha1.ACMESpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
With PR [cert-management#512](https://github.com/gardener/cert-management/pull/512) the `Issuer` resources must have the `cert.gardener.cloud/class` as specified in the deployment of the cert-controller-manager. Formerly it was only required for `Certificate` resources. It was introduced to avoid races if two instances of the cert-controller-manager use the same namespace for its issuer and only reconcile their own issuers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Change will only be effective with the next release of the cert-management.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add annotation `cert.gardener.cloud/class` for control plane issuers
```
