### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/docs/tutorials/tutorial-custom-domain-with-istio.md
+++ b/docs/tutorials/tutorial-custom-domain-with-istio.md
@@ -145,7 +145,7 @@ spec:
           server: 'https://acme-staging-v02.api.letsencrypt.org/directory'
   cloudProfileName: gcp
   kubernetes:
-    version: 1.28.2
+    version: 1.32.0
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -195,9 +195,9 @@ shoot.core.gardener.cloud/gsicdc created
 
 $ kgarden get shoot gsicdc --watch
 NAME     CLOUDPROFILE   VERSION   SEED   DOMAIN                                        HIBERNATION   OPERATION    PROGRESS   APISERVER     CONTROL       NODES     SYSTEM    AGE
-gsicdc   gcp            1.28.2    gcp    gsicdc.myproject.shoot.devgarden.cloud   Awake         Processing   38         Progressing   Progressing   Unknown   Unknown   83s
+gsicdc   gcp            1.32.0    gcp    gsicdc.myproject.shoot.devgarden.cloud   Awake         Processing   38         Progressing   Progressing   Unknown   Unknown   83s
 ...
-gsicdc   gcp            1.28.2    gcp    gsicdc.myproject.shoot.devgarden.cloud   Awake         Succeeded    100        True          True          True          False         6m7s
+gsicdc   gcp            1.32.0    gcp    gsicdc.myproject.shoot.devgarden.cloud   Awake         Succeeded    100        True          True          True          False         6m7s
 ```
 
 Get access to your freshly baked cluster and set your `KUBECONFIG`:

--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -171,7 +171,7 @@ spec:
         - --service-account-signing-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-account-key-file=/srv/kubernetes/service-account-key-bundle/bundle.key
         - --v=2
-        image: registry.k8s.io/kube-apiserver:v1.28.2
+        image: registry.k8s.io/kube-apiserver:v1.32.0
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         securityContext:

--- a/example/30-cluster.yaml
+++ b/example/30-cluster.yaml
@@ -20,7 +20,7 @@ spec:
       dns:
         domain: foo.bar.example.com
       kubernetes:
-        version: 1.28.2
+        version: 1.32.0
       resources:
         - name: issuer-custom-eab-hmackey
           resourceRef:

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config",

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -215,7 +215,7 @@ string
 <td>
 <code>propagationTimeout</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#duration-v1-meta">
 Kubernetes meta/v1.Duration
 </a>
 </em>

--- a/hack/api-reference/service.json
+++ b/hack/api-reference/service.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config",

--- a/renovate.json5
+++ b/renovate.json5
@@ -46,7 +46,6 @@
     "github.com/beorn7/perks",
     "github.com/blang/semver/v4",
     "github.com/brunoga/deep",
-    "github.com/cenkalti/backoff/v4",
     "github.com/cespare/xxhash/v2",
     "github.com/coreos/go-systemd/v22",
     "github.com/cyphar/filepath-securejoin",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`shoot-cert-service` no longer supports Shoots with Кubernetes version <= 1.28.
```
