### PR TITLE
Control-plane certificate: Use `dnsNames` instead of `commonName` for long domain names

### DIFF
--- a/pkg/controller/extension/controlplane/controlplanecert.go
+++ b/pkg/controller/extension/controlplane/controlplanecert.go
@@ -65,7 +65,15 @@ func (r *controlPlaneCert) reconcile(ctx context.Context) error {
 	result, err := controllerutils.CreateOrGetAndMergePatch(ctx, r.client, cert, func() error {
 		cert.Annotations = annotations
 		cert.Labels = labels
-		cert.Spec.CommonName = ptr.To("*." + r.domain)
+		dnsName := "*." + r.domain
+		if len(dnsName) <= 64 {
+			cert.Spec.CommonName = ptr.To(dnsName)
+			cert.Spec.DNSNames = nil
+		} else {
+			cert.Spec.CommonName = nil
+			cert.Spec.DNSNames = []string{dnsName}
+		}
+
 		cert.Spec.SecretLabels = labels
 		cert.Spec.SecretRef = &corev1.SecretReference{
 			Name:      SecretNameControlPlaneCert,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The `CommonName` is restricted to 64 characters. If the seed domain name is too long, the `dnsNames` field in the `Certificate` resource is used instead.

**Which issue(s) this PR fixes**:
Fixes #444 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Control-plane certificate: Use `dnsNames` field instead of `commonName` for long domain names > 64 characters.
```
