### PR TITLE
chore: Use Renovate preset for grouping Go updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,25 +1,15 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    'github>gardener/ci-infra//config/renovate/group-go-updates.json5',
   ],
+  dependencyDashboard: true,
   labels: [
     'kind/enhancement',
   ],
   postUpdateOptions: [
     'gomodTidy',
-  ],
-  packageRules: [
-    {
-      groupName: 'Go',
-      description: 'Group all Go dependencies together.',
-      matchPackageNames: [
-        'actions/go-versions',
-        'go',
-        'golang',
-      ],
-    },
   ],
   // The following list of dependencies to ignore is updated by `make generate`.
   // DO NOT EDIT THIS SECTION MANUALLY.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Uses the shared Renovate preset for grouping Go updates:
https://github.com/gardener/ci-infra/blob/master/config/renovate/group-go-updates.json5

Follow-up to:
* https://github.com/gardener/gardener-extension-shoot-cert-service/pull/452

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
