### PR TITLE
`cert-class` needs also to be set for source controllers

### DIFF
--- a/pkg/controller/extension/shared/deployer_seed.go
+++ b/pkg/controller/extension/shared/deployer_seed.go
@@ -494,7 +494,7 @@ func (d *Deployer) args() []string {
 	} else {
 		args = append(args,
 			fmt.Sprintf("--namespace=%s", d.values.Namespace),
-			fmt.Sprintf("--issuer.cert-class=%s", d.values.CertClass),
+			fmt.Sprintf("--cert-class=%s", d.values.CertClass),
 			"--use-dnsrecords=true",
 		)
 	}

--- a/pkg/controller/extension/shared/deployer_test.go
+++ b/pkg/controller/extension/shared/deployer_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Deployer", func() {
 				args = append(args, "--source=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig")
 			} else {
 				args = append(args,
-					"--issuer.cert-class="+certClass,
+					"--cert-class="+certClass,
 					"--use-dnsrecords=true",
 				)
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
On introducing the `cert-class=garden` for the deployment on the runtime cluster, the command line argument was restricted to the issuer controller. But there are now also source resources like `Ingress` which need to use the correct `cert-class`. This PR sets the cert-class globally for all controllers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Deployment on runtime cluster: `cert-class` needs also to be set for source controllers.
```
