### PR TITLE
chore(pkg/controller): make seed `deployer` VPA use update mode `Recr…

### DIFF
--- a/pkg/controller/extension/shared/deployer_seed.go
+++ b/pkg/controller/extension/shared/deployer_seed.go
@@ -35,7 +35,7 @@ const (
 	ingressCertWorkers = 5
 	certWorkers        = 5
 	issuerWorkers      = 2
-	vpaUpdateMode      = "Auto"
+	vpaUpdateMode      = "Recreate"
 
 	defaultAlgorithm               = "RSA"
 	defaultSizeRSA                 = 3072

--- a/pkg/controller/extension/shared/deployer_test.go
+++ b/pkg/controller/extension/shared/deployer_test.go
@@ -833,7 +833,7 @@ var _ = Describe("Deployer", func() {
 							Name:       "cert-controller-manager",
 						},
 						UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-							UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
+							UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 						},
 						ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 							ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:

With the [deprecation](https://github.com/kubernetes/autoscaler/pull/8426) of _updateMode_ [Auto](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/quickstart.md#quick-start), we need to migrate our workloads to use it's only fallback implementation - _updateMode_ `Recreate`. This pull request instruments the `Seed` _deployer_ VPA resource with _updateMode_ `Recreate`.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/12903

**Special notes for your reviewer**:

A leftover missed in https://github.com/gardener/gardener-extension-shoot-cert-service/pull/470

<!--
**Release note**:
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
```other operator
Migrate the extension VPAs from the deprecated update mode `Auto` to its only fallback strategy - update mode `Recreate`.
```
-->