### PR TITLE
feat(ci): Validate release-notes for PRs

### DIFF
--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  validate-releaes-notes:
+  validate-release-notes:
     runs-on: ${{ vars.DEFAULT_RUNNER || 'ubuntu-latest' }}
     steps:
     - name: install-gardener-gha-libs


### PR DESCRIPTION
**How to categorize this PR?**

/area open-source
/kind test

**What this PR does / why we need it**:
Introduces a workflow which runs on PRs to validate release-notes from PR text.
Please see [release-notes documentation](https://gardener.github.io/cc-utils/release_notes.html) for details.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
```other developer
NONE
```