### PR TITLE
Adds fallback mechanism to handle shoot deletion failures

### DIFF
--- a/pkg/controller/extension/shared/deployer_shoot.go
+++ b/pkg/controller/extension/shared/deployer_shoot.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -77,6 +78,20 @@ func (d *Deployer) DeleteShootManagedResourceAndWait(ctx context.Context, c clie
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return managedresources.WaitUntilDeleted(timeoutCtx, c, d.values.Namespace, v1alpha1.CertManagementResourceNameShoot)
+}
+
+func (d *Deployer) DropShootManagedResource(ctx context.Context, c client.Client) error {
+	if !d.values.ShootDeployment {
+		return fmt.Errorf("only supported for shoot deployment")
+	}
+
+	mr := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: v1alpha1.CertManagementResourceNameShoot, Namespace: d.values.Namespace}}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(mr), mr); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(mr.DeepCopy())
+	mr.Finalizers = nil
+	return c.Patch(ctx, mr, patch)
 }
 
 func (d *Deployer) createShootRole() *rbacv1.Role {

--- a/pkg/controller/extension/shared/deployer_shoot.go
+++ b/pkg/controller/extension/shared/deployer_shoot.go
@@ -80,6 +80,7 @@ func (d *Deployer) DeleteShootManagedResourceAndWait(ctx context.Context, c clie
 	return managedresources.WaitUntilDeleted(timeoutCtx, c, d.values.Namespace, v1alpha1.CertManagementResourceNameShoot)
 }
 
+// TODO(MartinWeindel) Revert PR #535, when gardener/gardener#14568 is implemented.
 func (d *Deployer) DropShootManagedResource(ctx context.Context, c client.Client) error {
 	if !d.values.ShootDeployment {
 		return fmt.Errorf("only supported for shoot deployment")

--- a/pkg/controller/extension/shared/deployer_test.go
+++ b/pkg/controller/extension/shared/deployer_test.go
@@ -1046,6 +1046,73 @@ var _ = Describe("Deployer", func() {
 		}
 	})
 
+	Describe("DropShootManagedResource", func() {
+		BeforeEach(func() {
+			values = Values{
+				Namespace:       "shoot--foo--bar",
+				ShootDeployment: true,
+			}
+		})
+
+		It("should remove finalizers from the shoot managed resource", func() {
+			// Create a managed resource with finalizers
+			mr := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       servicev1alpha1.CertManagementResourceNameShoot,
+					Namespace:  values.Namespace,
+					Finalizers: []string{"resources.gardener.cloud/gardener", "custom-finalizer"},
+				},
+			}
+			Expect(c.Create(ctx, mr)).To(Succeed())
+
+			// Verify finalizers are present
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(mr), mr)).To(Succeed())
+			Expect(mr.Finalizers).To(HaveLen(2))
+
+			// Call DropShootManagedResource
+			deployer := NewDeployer(values)
+			Expect(deployer.DropShootManagedResource(ctx, c)).To(Succeed())
+
+			// Verify finalizers are removed
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(mr), mr)).To(Succeed())
+			Expect(mr.Finalizers).To(BeEmpty())
+		})
+
+		It("should return an error if managed resource does not exist", func() {
+			deployer := NewDeployer(values)
+			err := deployer.DropShootManagedResource(ctx, c)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should return an error if not configured for shoot deployment", func() {
+			values.ShootDeployment = false
+			deployer := NewDeployer(values)
+			err := deployer.DropShootManagedResource(ctx, c)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("only supported for shoot deployment"))
+		})
+
+		It("should handle managed resource with no finalizers", func() {
+			// Create a managed resource without finalizers
+			mr := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      servicev1alpha1.CertManagementResourceNameShoot,
+					Namespace: values.Namespace,
+				},
+			}
+			Expect(c.Create(ctx, mr)).To(Succeed())
+
+			// Call DropShootManagedResource
+			deployer := NewDeployer(values)
+			Expect(deployer.DropShootManagedResource(ctx, c)).To(Succeed())
+
+			// Verify it still succeeds (no-op)
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(mr), mr)).To(Succeed())
+			Expect(mr.Finalizers).To(BeEmpty())
+		})
+	})
+
 	Describe("DeployShootManagedResource", func() {
 		It("should deploy the standard shoot managed resource", func() {
 			testShootManagedResource(standardShootResources(), false)

--- a/pkg/controller/extension/shoot/actuator.go
+++ b/pkg/controller/extension/shoot/actuator.go
@@ -94,7 +94,18 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, ex *extensionsv1
 	log.Info("Component is being deleted", "component", "cert-management", "namespace", namespace)
 
 	if err := a.deleteShootResourcesForShoot(ctx, log, namespace); err != nil {
-		return err
+		// If there are foreign finalizers on certificate resources on the cluster, the deletion of
+		// its CRD may be blocked. As no external resources need to be cleaned up, it is safe to ignore it by
+		// removing the finalizer from the shoot managed resource.
+		// This will only be applied if shoot is deleting since more than 10 min.
+		cluster, _ := controller.GetCluster(ctx, a.client, namespace)
+		if cluster != nil && cluster.Shoot != nil && cluster.Shoot.DeletionTimestamp != nil && time.Since(cluster.Shoot.DeletionTimestamp.Time) > 10*time.Minute {
+			err = a.dropShootResourcesForShoot(ctx, log, namespace)
+		}
+
+		if err != nil {
+			return err
+		}
 	}
 	return a.deleteSeedResourcesForShoot(ctx, log, namespace)
 }
@@ -183,6 +194,11 @@ func (a *actuator) deleteSeedResourcesForShoot(ctx context.Context, log logr.Log
 func (a *actuator) deleteShootResourcesForShoot(ctx context.Context, log logr.Logger, namespace string) error {
 	log.Info("Deleting managed resource for shoot", "namespace", namespace)
 	return shared.NewDeployer(shared.Values{Namespace: namespace, ShootDeployment: true}).DeleteShootManagedResourceAndWait(ctx, a.client, 2*time.Minute)
+}
+
+func (a *actuator) dropShootResourcesForShoot(ctx context.Context, log logr.Logger, namespace string) error {
+	log.Info("Dropping managed resource for shoot", "namespace", namespace)
+	return shared.NewDeployer(shared.Values{Namespace: namespace, ShootDeployment: true}).DropShootManagedResource(ctx, a.client)
 }
 
 func (a *actuator) updateStatus(ctx context.Context, ex *extensionsv1alpha1.Extension, certConfig *service.CertConfig) error {

--- a/pkg/controller/extension/shoot/actuator.go
+++ b/pkg/controller/extension/shoot/actuator.go
@@ -94,6 +94,8 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, ex *extensionsv1
 	log.Info("Component is being deleted", "component", "cert-management", "namespace", namespace)
 
 	if err := a.deleteShootResourcesForShoot(ctx, log, namespace); err != nil {
+		// TODO(MartinWeindel) Revert PR #535, when gardener/gardener#14568 is implemented.
+
 		// If there are foreign finalizers on certificate resources on the cluster, the deletion of
 		// its CRD may be blocked. As no external resources need to be cleaned up, it is safe to ignore it by
 		// removing the finalizer from the shoot managed resource.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
*Summary*                                                                                                                                                                                                                                                                                                                     
                                               
  Adds a fallback mechanism to handle shoot deletion failures when certificate resources have foreign finalizers that block CRD deletion.                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                            
*Changes*                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                            
  - New function DropShootManagedResource: Removes finalizers from the shoot managed resource to allow cleanup to proceed when deletion is blocked                                                                                                                                                                            
  - Updated Delete actuator logic: If cleanup fails and the shoot has been deleting for more than 10 minutes, drops the managed resource as a fallback                                                                                                                                                                      
  - Comprehensive unit tests: Tests for successful finalizer removal, error handling, and edge cases                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                              
  *Rationale*                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                              
  When foreign finalizers exist on certificate resources in the cluster, the deletion of the certificate CRD may be blocked indefinitely. Since no external resources need cleanup in this scenario, it's safe to remove the finalizer from the shoot managed resource after a reasonable timeout (10 minutes) to allow shoot deletion to complete.   

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adds a fallback mechanism to handle shoot deletion failures when certificate resources have foreign finalizers that block CRD deletion.
```
