### PR TITLE
Watch shoot-dns-service Extension to detect next-gen controller switch

### DIFF
--- a/pkg/controller/extension/shoot/actuator.go
+++ b/pkg/controller/extension/shoot/actuator.go
@@ -19,9 +19,9 @@ import (
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/go-logr/logr"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -150,7 +150,7 @@ func (a *actuator) createValues(
 		Replicas:        1,
 	}
 
-	values.NextGenDNSShootService, err = isNextGenDNSShootServiceEnabled(cluster)
+	values.NextGenDNSShootService, err = a.isNextGenDNSShootServiceEnabled(ctx, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -263,24 +263,13 @@ func (a *actuator) createGardenClient() (client.Client, error) {
 	})
 }
 
-func isNextGenDNSShootServiceEnabled(cluster *controller.Cluster) (bool, error) {
-	for _, ext := range cluster.Shoot.Spec.Extensions {
-		if ext.Type == "shoot-dns-service" {
-			if ext.ProviderConfig == nil || ext.ProviderConfig.Raw == nil {
-				return false, nil
-			}
-			providerConfig := map[string]any{}
-			if err := yaml.Unmarshal(ext.ProviderConfig.Raw, &providerConfig); err != nil {
-				return false, fmt.Errorf("failed to unmarshal shoot-dns-service provider config: %w", err)
-			}
-			if v, ok := providerConfig["useNextGenerationController"]; ok {
-				useNextGen, ok := v.(bool)
-				if ok && useNextGen {
-					return true, nil
-				}
-			}
+func (a *actuator) isNextGenDNSShootServiceEnabled(ctx context.Context, namespace string) (bool, error) {
+	dnsExtension := &extensionsv1alpha1.Extension{}
+	if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: dnsServiceExtensionName}, dnsExtension); err != nil {
+		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
+		return false, fmt.Errorf("fetching shoot-dns-service extension failed: %w", err)
 	}
-	return false, nil
+	return dnsExtension.Annotations[useNextGenerationControllerAnnotation] == "true", nil
 }

--- a/pkg/controller/extension/shoot/add.go
+++ b/pkg/controller/extension/shoot/add.go
@@ -9,10 +9,16 @@ import (
 	"fmt"
 	"slices"
 
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/extension"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/gardener/gardener-extension-shoot-cert-service/pkg/apis/config"
 	"github.com/gardener/gardener-extension-shoot-cert-service/pkg/controller/extension/shared"
@@ -23,6 +29,12 @@ const (
 	Type = "shoot-cert-service"
 	// ControllerName is the name of the shoot cert service controller.
 	ControllerName = "shoot-cert-service"
+	// dnsServiceExtensionName is the name of the shoot-dns-service Extension resource that is watched
+	// to trigger reconciliation of the shoot-cert-service Extension in the same namespace.
+	dnsServiceExtensionName = "shoot-dns-service"
+	// useNextGenerationControllerAnnotation is the annotation on the shoot-dns-service Extension
+	// indicating whether the next-generation DNS controller is in use.
+	useNextGenerationControllerAnnotation = "service.dns.extensions.gardener.cloud/use-next-generation-controller"
 )
 
 var (
@@ -58,6 +70,15 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 
 	extensionClasses := []extensionsv1alpha1.ExtensionClass{extensionsv1alpha1.ExtensionClassShoot}
 
+	watchBuilder := extensionscontroller.NewWatchBuilder(func(c controller.Controller) error {
+		return c.Watch(source.Kind(
+			mgr.GetCache(),
+			&extensionsv1alpha1.Extension{},
+			handler.TypedEnqueueRequestsFromMapFunc(mapDNSServiceExtensionToCertServiceExtension()),
+			&dnsServiceExtensionPredicate{},
+		))
+	})
+
 	return extension.Add(mgr, extension.AddArgs{
 		Actuator:          NewActuator(mgr, opts.ServiceConfig, extensionClasses),
 		ControllerOptions: opts.ControllerOptions,
@@ -67,5 +88,49 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 		Predicates:        predicates,
 		Type:              Type,
 		ExtensionClasses:  extensionClasses,
+		WatchBuilder:      watchBuilder,
 	})
+}
+
+// mapDNSServiceExtensionToCertServiceExtension maps a shoot-dns-service Extension event to a reconcile
+// request for the shoot-cert-service Extension in the same namespace.
+func mapDNSServiceExtensionToCertServiceExtension() func(context.Context, *extensionsv1alpha1.Extension) []reconcile.Request {
+	return func(_ context.Context, ex *extensionsv1alpha1.Extension) []reconcile.Request {
+		if ex == nil || ex.Name != dnsServiceExtensionName {
+			return nil
+		}
+		return []reconcile.Request{{
+			NamespacedName: client.ObjectKey{
+				Name:      Type,
+				Namespace: ex.Namespace,
+			},
+		}}
+	}
+}
+
+// dnsServiceExtensionPredicate filters Extension events to only those for the shoot-dns-service
+// Extension on create, and on update only when the next-generation controller annotation changes.
+type dnsServiceExtensionPredicate struct{}
+
+func (dnsServiceExtensionPredicate) Create(e event.TypedCreateEvent[*extensionsv1alpha1.Extension]) bool {
+	return e.Object != nil && e.Object.Name == dnsServiceExtensionName
+}
+
+func (dnsServiceExtensionPredicate) Update(e event.TypedUpdateEvent[*extensionsv1alpha1.Extension]) bool {
+	if e.ObjectNew == nil || e.ObjectNew.Name != dnsServiceExtensionName {
+		return false
+	}
+	oldValue := ""
+	if e.ObjectOld != nil {
+		oldValue = e.ObjectOld.Annotations[useNextGenerationControllerAnnotation]
+	}
+	return oldValue != e.ObjectNew.Annotations[useNextGenerationControllerAnnotation]
+}
+
+func (dnsServiceExtensionPredicate) Delete(_ event.TypedDeleteEvent[*extensionsv1alpha1.Extension]) bool {
+	return false
+}
+
+func (dnsServiceExtensionPredicate) Generic(_ event.TypedGenericEvent[*extensionsv1alpha1.Extension]) bool {
+	return false
 }

--- a/pkg/controller/extension/shoot/add_test.go
+++ b/pkg/controller/extension/shoot/add_test.go
@@ -5,11 +5,15 @@
 package shoot
 
 import (
+	"context"
+
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("dnsServiceExtensionPredicate", func() {
@@ -113,5 +117,47 @@ var _ = Describe("dnsServiceExtensionPredicate", func() {
 				Object: makeExtension(dnsServiceExtensionName, nil),
 			})).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("mapDNSServiceExtensionToCertServiceExtension", func() {
+	var (
+		ctx     = context.Background()
+		mapFunc = mapDNSServiceExtensionToCertServiceExtension()
+
+		makeExtension = func(name, namespace string) *extensionsv1alpha1.Extension {
+			return &extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+		}
+	)
+
+	It("should map a shoot-dns-service Extension to a request for the shoot-cert-service Extension in the same namespace", func() {
+		Expect(mapFunc(ctx, makeExtension(dnsServiceExtensionName, "shoot--foo--bar"))).To(Equal([]reconcile.Request{{
+			NamespacedName: client.ObjectKey{
+				Name:      Type,
+				Namespace: "shoot--foo--bar",
+			},
+		}}))
+	})
+
+	It("should return nil for an Extension with a different name", func() {
+		Expect(mapFunc(ctx, makeExtension("shoot-other-service", "shoot--foo--bar"))).To(BeNil())
+	})
+
+	It("should return nil for a nil Extension", func() {
+		Expect(mapFunc(ctx, nil)).To(BeNil())
+	})
+
+	It("should preserve the namespace from the source Extension", func() {
+		Expect(mapFunc(ctx, makeExtension(dnsServiceExtensionName, "shoot--other--ns"))).To(Equal([]reconcile.Request{{
+			NamespacedName: client.ObjectKey{
+				Name:      Type,
+				Namespace: "shoot--other--ns",
+			},
+		}}))
 	})
 })

--- a/pkg/controller/extension/shoot/add_test.go
+++ b/pkg/controller/extension/shoot/add_test.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shoot
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("dnsServiceExtensionPredicate", func() {
+	var (
+		predicate dnsServiceExtensionPredicate
+
+		makeExtension = func(name string, annotations map[string]string) *extensionsv1alpha1.Extension {
+			return &extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Namespace:   "shoot--foo--bar",
+					Annotations: annotations,
+				},
+			}
+		}
+	)
+
+	Describe("Create", func() {
+		It("should accept the shoot-dns-service Extension", func() {
+			Expect(predicate.Create(event.TypedCreateEvent[*extensionsv1alpha1.Extension]{
+				Object: makeExtension(dnsServiceExtensionName, nil),
+			})).To(BeTrue())
+		})
+
+		It("should reject Extensions with a different name", func() {
+			Expect(predicate.Create(event.TypedCreateEvent[*extensionsv1alpha1.Extension]{
+				Object: makeExtension("shoot-other-service", nil),
+			})).To(BeFalse())
+		})
+
+		It("should reject a nil object", func() {
+			Expect(predicate.Create(event.TypedCreateEvent[*extensionsv1alpha1.Extension]{
+				Object: nil,
+			})).To(BeFalse())
+		})
+	})
+
+	Describe("Update", func() {
+		It("should reject Extensions with a different name", func() {
+			Expect(predicate.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Extension]{
+				ObjectOld: makeExtension("shoot-other-service", nil),
+				ObjectNew: makeExtension("shoot-other-service", map[string]string{useNextGenerationControllerAnnotation: "true"}),
+			})).To(BeFalse())
+		})
+
+		It("should reject when the annotation is unchanged", func() {
+			annotations := map[string]string{useNextGenerationControllerAnnotation: "true"}
+			Expect(predicate.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Extension]{
+				ObjectOld: makeExtension(dnsServiceExtensionName, annotations),
+				ObjectNew: makeExtension(dnsServiceExtensionName, annotations),
+			})).To(BeFalse())
+		})
+
+		It("should accept when the annotation is added", func() {
+			Expect(predicate.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Extension]{
+				ObjectOld: makeExtension(dnsServiceExtensionName, nil),
+				ObjectNew: makeExtension(dnsServiceExtensionName, map[string]string{useNextGenerationControllerAnnotation: "true"}),
+			})).To(BeTrue())
+		})
+
+		It("should accept when the annotation value changes", func() {
+			Expect(predicate.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Extension]{
+				ObjectOld: makeExtension(dnsServiceExtensionName, map[string]string{useNextGenerationControllerAnnotation: "false"}),
+				ObjectNew: makeExtension(dnsServiceExtensionName, map[string]string{useNextGenerationControllerAnnotation: "true"}),
+			})).To(BeTrue())
+		})
+
+		It("should accept when the annotation is removed", func() {
+			Expect(predicate.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Extension]{
+				ObjectOld: makeExtension(dnsServiceExtensionName, map[string]string{useNextGenerationControllerAnnotation: "true"}),
+				ObjectNew: makeExtension(dnsServiceExtensionName, nil),
+			})).To(BeTrue())
+		})
+
+		It("should treat a nil ObjectOld as no prior annotation", func() {
+			Expect(predicate.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Extension]{
+				ObjectOld: nil,
+				ObjectNew: makeExtension(dnsServiceExtensionName, map[string]string{useNextGenerationControllerAnnotation: "true"}),
+			})).To(BeTrue())
+		})
+
+		It("should reject a nil ObjectNew", func() {
+			Expect(predicate.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Extension]{
+				ObjectOld: makeExtension(dnsServiceExtensionName, nil),
+				ObjectNew: nil,
+			})).To(BeFalse())
+		})
+	})
+
+	Describe("Delete", func() {
+		It("should always reject", func() {
+			Expect(predicate.Delete(event.TypedDeleteEvent[*extensionsv1alpha1.Extension]{
+				Object: makeExtension(dnsServiceExtensionName, nil),
+			})).To(BeFalse())
+		})
+	})
+
+	Describe("Generic", func() {
+		It("should always reject", func() {
+			Expect(predicate.Generic(event.TypedGenericEvent[*extensionsv1alpha1.Extension]{
+				Object: makeExtension(dnsServiceExtensionName, nil),
+			})).To(BeFalse())
+		})
+	})
+})

--- a/pkg/controller/extension/shoot/add_test.go
+++ b/pkg/controller/extension/shoot/add_test.go
@@ -7,11 +7,14 @@ package shoot
 import (
 	"context"
 
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -160,4 +163,73 @@ var _ = Describe("mapDNSServiceExtensionToCertServiceExtension", func() {
 			},
 		}}))
 	})
+})
+
+var _ = Describe("isNextGenDNSShootServiceEnabled", func() {
+	const namespace = "shoot--foo--bar"
+
+	var (
+		ctx = context.Background()
+
+		scheme *runtime.Scheme
+		c      client.Client
+		a      *actuator
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(extensionscontroller.AddToScheme(scheme)).To(Succeed())
+
+		c = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+		a = &actuator{client: c}
+	})
+
+	DescribeTable("should return whether the next-gen DNS controller is enabled",
+		func(existing *extensionsv1alpha1.Extension, expected bool) {
+			if existing != nil {
+				Expect(c.Create(ctx, existing)).To(Succeed())
+			}
+
+			enabled, err := a.isNextGenDNSShootServiceEnabled(ctx, namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(enabled).To(Equal(expected))
+		},
+		Entry("Extension does not exist", nil, false),
+		Entry("Extension has no annotations",
+			&extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{Name: dnsServiceExtensionName, Namespace: namespace},
+			}, false),
+		Entry("annotation value is 'false'",
+			&extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        dnsServiceExtensionName,
+					Namespace:   namespace,
+					Annotations: map[string]string{useNextGenerationControllerAnnotation: "false"},
+				},
+			}, false),
+		Entry("annotation value is some other string",
+			&extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        dnsServiceExtensionName,
+					Namespace:   namespace,
+					Annotations: map[string]string{useNextGenerationControllerAnnotation: "True"},
+				},
+			}, false),
+		Entry("annotation value is 'true'",
+			&extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        dnsServiceExtensionName,
+					Namespace:   namespace,
+					Annotations: map[string]string{useNextGenerationControllerAnnotation: "true"},
+				},
+			}, true),
+		Entry("Extension with the same name lives in another namespace",
+			&extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        dnsServiceExtensionName,
+					Namespace:   "shoot--other--ns",
+					Annotations: map[string]string{useNextGenerationControllerAnnotation: "true"},
+				},
+			}, false),
+	)
 })

--- a/pkg/controller/extension/shoot/shoot_suite_test.go
+++ b/pkg/controller/extension/shoot/shoot_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shoot
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extension Shoot Controller Suite")
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
## Summary
  
  Switches the `shoot-cert-service` actuator to read the next-generation DNS controller flag from the live `shoot-dns-service` Extension's annotation instead of parsing it from the shoot spec's provider config, and adds a watch so cert-service reconciles when that annotation changes.

  ## Changes

  - **`pkg/controller/extension/shoot/actuator.go`**
    - Replaced the spec-based `isNextGenDNSShootServiceEnabled(cluster)` (which YAML-unmarshalled `useNextGenerationController` from the shoot's `shoot-dns-service` extension provider config) with a method that `GET`s the `shoot-dns-service` Extension in the seed namespace and
  reads the `service.dns.extensions.gardener.cloud/use-next-generation-controller` annotation.
    - Treats a missing Extension as "disabled"; propagates other API errors.

  - **`pkg/controller/extension/shoot/add.go`**
    - Added constants `dnsServiceExtensionName` and `useNextGenerationControllerAnnotation`.
    - Registered a `WatchBuilder` on `extensionsv1alpha1.Extension` that maps a `shoot-dns-service` event to a reconcile request for the `shoot-cert-service` Extension in the same namespace.
    - Added `dnsServiceExtensionPredicate` that:
      - accepts Create events for the `shoot-dns-service` Extension,
      - accepts Update events only when the next-gen annotation value actually changes,
      - rejects Delete and Generic events.

  - **`pkg/controller/extension/shoot/add_test.go` + `shoot_suite_test.go`** (new)
    - Ginkgo suite for the `shoot` package (mirrors the `controlplane` suite).
    - Predicate tests covering: wrong name, unchanged annotation, annotation added / changed / removed, nil `ObjectOld`, nil `ObjectNew`, and Delete/Generic always-reject.

  ## Why

The next-gen DNS controller flag can flip at runtime on the dns-service Extension. Reading it from the shoot spec was static and missed updates; reading it from the live Extension plus a watch ensures cert-service reconciles promptly when the flag changes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Depends on https://github.com/gardener/gardener-extension-shoot-dns-service/pull/746

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Watch shoot-dns-service Extension to detect next-gen controller switch
```
