### PR TITLE
Allow domain names in `precheckNameservers` and support `host:port` format

### DIFF
--- a/pkg/apis/config/validation/validation.go
+++ b/pkg/apis/config/validation/validation.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/gardener/gardener/pkg/utils"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/gardener-extension-shoot-cert-service/pkg/apis/config"
@@ -65,8 +66,8 @@ func validateACME(acme *config.ACME, fldPath *field.Path) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, "must contain at least one DNS server IP"))
 		} else {
 			for i, server := range servers {
-				if net.ParseIP(server) == nil {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, fmt.Sprintf("invalid IP for %d. DNS server", i+1)))
+				if err := checkIPOrDomain(server, i); err != nil {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, err.Error()))
 				}
 			}
 		}
@@ -78,6 +79,23 @@ func validateACME(acme *config.ACME, fldPath *field.Path) field.ErrorList {
 		}
 	}
 	return allErrs
+}
+
+func checkIPOrDomain(server string, idx int) error {
+	// Accept host or host:port. net.SplitHostPort handles [::1]:53 and bare IPs/domains.
+	// For bare bracketed IPv6 like [::1] (no port), SplitHostPort fails; strip the brackets manually.
+	host, _, err := net.SplitHostPort(server)
+	if err != nil {
+		host = strings.TrimSuffix(strings.TrimPrefix(server, "["), "]")
+	}
+	if net.ParseIP(host) != nil {
+		return nil
+	}
+	fqdn := strings.TrimSuffix(host, ".")
+	if errs := k8svalidation.IsDNS1123Subdomain(fqdn); len(errs) > 0 {
+		return fmt.Errorf("invalid IP or domain name for DNS server #%d: '%s' (%s)", idx+1, server, strings.Join(errs, "; "))
+	}
+	return nil
 }
 
 func validateCA(ca *config.CA, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/config/validation/validation.go
+++ b/pkg/apis/config/validation/validation.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/gardener/gardener/pkg/utils"
@@ -63,10 +64,10 @@ func validateACME(acme *config.ACME, fldPath *field.Path) field.ErrorList {
 	if acme.PrecheckNameservers != nil {
 		servers := strings.Split(*acme.PrecheckNameservers, ",")
 		if len(servers) == 1 && len(servers[0]) == 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, "must contain at least one DNS server IP"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, "must contain at least one DNS server address"))
 		} else {
-			for i, server := range servers {
-				if err := checkIPOrDomain(server, i); err != nil {
+			for _, server := range servers {
+				if err := ValidateNameserver(server); err != nil {
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("precheckNameservers"), *acme.PrecheckNameservers, err.Error()))
 				}
 			}
@@ -81,19 +82,38 @@ func validateACME(acme *config.ACME, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-func checkIPOrDomain(server string, idx int) error {
-	// Accept host or host:port. net.SplitHostPort handles [::1]:53 and bare IPs/domains.
-	// For bare bracketed IPv6 like [::1] (no port), SplitHostPort fails; strip the brackets manually.
-	host, _, err := net.SplitHostPort(server)
+// ValidateNameserver validates a nameserver address, accepting an IP address or domain name with an optional port (host:port format).
+func ValidateNameserver(server string) error {
+	host, port, err := net.SplitHostPort(server)
 	if err != nil {
-		host = strings.TrimSuffix(strings.TrimPrefix(server, "["), "]")
+		// Handle bare bracketed IPv6 like [::1] — valid but SplitHostPort requires a port.
+		if inner, ok := strings.CutPrefix(server, "["); ok {
+			inner = strings.TrimSuffix(inner, "]")
+			if !strings.HasSuffix(server, "]") || net.ParseIP(inner) == nil {
+				return fmt.Errorf("'%s' is no valid nameserver address", server)
+			}
+			host = inner
+		} else {
+			host = server
+		}
+		port = "53"
 	}
-	if net.ParseIP(host) != nil {
-		return nil
+	if net.ParseIP(host) == nil {
+		if errs := k8svalidation.IsDNS1123Subdomain(strings.TrimSuffix(host, ".")); len(errs) > 0 || len(strings.Trim(host, "0123456789.")) == 0 {
+			details := ""
+			if len(errs) > 0 {
+				details = fmt.Sprintf(" (%s)", strings.Join(errs, "; "))
+			}
+			return fmt.Errorf("'%s' is no valid IP address or domain name%s", host, details)
+		}
 	}
-	fqdn := strings.TrimSuffix(host, ".")
-	if errs := k8svalidation.IsDNS1123Subdomain(fqdn); len(errs) > 0 {
-		return fmt.Errorf("invalid IP or domain name for DNS server #%d: '%s' (%s)", idx+1, server, strings.Join(errs, "; "))
+
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("'%s' is no valid port", port)
+	}
+	if n < 1 || n > 65535 {
+		return fmt.Errorf("'%s' is no valid port number", port)
 	}
 	return nil
 }

--- a/pkg/apis/config/validation/validation_test.go
+++ b/pkg/apis/config/validation/validation_test.go
@@ -44,6 +44,36 @@ var _ = Describe("Validation", func() {
 		}
 	)
 
+	DescribeTable("#ValidateNameserver",
+		func(server string, errMatcher gomegatypes.GomegaMatcher) {
+			err := validation.ValidateNameserver(server)
+			Expect(err).To(errMatcher)
+		},
+		// valid IP addresses
+		Entry("IPv4", "8.8.8.8", BeNil()),
+		Entry("IPv4 with port", "8.8.8.8:53", BeNil()),
+		Entry("IPv6", "2001:db8::1", BeNil()),
+		Entry("IPv6 with brackets", "[::1]", BeNil()),
+		Entry("IPv6 with brackets and port", "[::1]:53", BeNil()),
+		Entry("IPv6 with brackets and custom port", "[2001:db8::1]:5353", BeNil()),
+		// valid domain names
+		Entry("domain name", "foo.com", BeNil()),
+		Entry("domain name with hyphen", "foo-2.bla.net", BeNil()),
+		Entry("FQDN with trailing dot", "foo-2.bla.net.", BeNil()),
+		Entry("domain name with custom port", "ns1.example.com:5353", BeNil()),
+		Entry("FQDN with port", "ns1.example.com.:53", BeNil()),
+		// invalid host
+		Entry("invalid domain (leading hyphen)", "-foo-.com", MatchError(ContainSubstring("is no valid IP address or domain name"))),
+		Entry("invalid domain (percent-encoded char)", "dns.server.te%st", MatchError(ContainSubstring("is no valid IP address or domain name"))),
+		Entry("pure numeric dotted string", "1.2.3", MatchError(ContainSubstring("is no valid IP address or domain name"))),
+		// invalid port
+		Entry("port out of range", "8.8.8.8:123456", MatchError(ContainSubstring("is no valid port number"))),
+		Entry("non-numeric port", "8.8.8.8:abc", MatchError(ContainSubstring("is no valid port"))),
+		// malformed brackets
+		Entry("unclosed bracket", "[::1", MatchError(ContainSubstring("is no valid nameserver address"))),
+		Entry("brackets around non-IP", "[notanip]", MatchError(ContainSubstring("is no valid nameserver address"))),
+	)
+
 	DescribeTable("#ValidateConfiguration",
 		func(config config.Configuration, match gomegatypes.GomegaMatcher) {
 			err := validation.ValidateConfiguration(&config)

--- a/pkg/apis/config/validation/validation_test.go
+++ b/pkg/apis/config/validation/validation_test.go
@@ -82,31 +82,72 @@ var _ = Describe("Validation", func() {
 				"Field": Equal("acme.email"),
 			})),
 		)),
-		Entry("Invalid precheck nameservers and caCertificates", config.Configuration{
+		Entry("Invalid precheck caCertificates", config.Configuration{
+			IssuerName: "gardener",
+			ACME: &config.ACME{
+				Email:          validACME.Email,
+				Server:         validACME.Server,
+				CACertificates: new("blabla"),
+			},
+		}, ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("acme.caCertificates"),
+			})),
+		)),
+		Entry("Invalid precheck nameservers (empty)", config.Configuration{
 			IssuerName: "gardener",
 			ACME: &config.ACME{
 				Email:               validACME.Email,
 				Server:              validACME.Server,
-				PrecheckNameservers: new("8.8.8.8,foo.com"),
-				CACertificates:      new("blabla"),
+				PrecheckNameservers: new(""),
 			},
 		}, ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("acme.precheckNameservers"),
 			})),
-			PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("acme.caCertificates"),
-			})),
 		)),
-		Entry("Valid precheck nameservers and caCertificates", config.Configuration{
+		Entry("Invalid precheck nameservers", config.Configuration{
 			IssuerName: "gardener",
 			ACME: &config.ACME{
 				Email:               validACME.Email,
 				Server:              validACME.Server,
-				PrecheckNameservers: new("8.8.8.8,172.11.22.253"),
-				CACertificates:      new(validCACerts()),
+				PrecheckNameservers: new("-foo-.com"),
+			},
+		}, ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("acme.precheckNameservers"),
+			})),
+		)),
+		Entry("Valid precheck nameservers", config.Configuration{
+			IssuerName: "gardener",
+			ACME: &config.ACME{
+				Email:               validACME.Email,
+				Server:              validACME.Server,
+				PrecheckNameservers: new("8.8.8.8,172.11.22.253,8.8.8.8:53,2001:db8::1,[::1],[::1]:53,foo.com,foo-2.bla.net.,ns1.example.com:5353"),
+			},
+		}, BeEmpty()),
+		Entry("Invalid precheck nameservers (bad domain with port)", config.Configuration{
+			IssuerName: "gardener",
+			ACME: &config.ACME{
+				Email:               validACME.Email,
+				Server:              validACME.Server,
+				PrecheckNameservers: new("-bad-.com:53"),
+			},
+		}, ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("acme.precheckNameservers"),
+			})),
+		)),
+		Entry("Valid caCertificates", config.Configuration{
+			IssuerName: "gardener",
+			ACME: &config.ACME{
+				Email:          validACME.Email,
+				Server:         validACME.Server,
+				CACertificates: new(validCACerts()),
 			},
 		}, BeEmpty()),
 		Entry("Invalid DefaultRequestsPerDayQuota", config.Configuration{

--- a/pkg/apis/service/validation/validation.go
+++ b/pkg/apis/service/validation/validation.go
@@ -5,18 +5,15 @@
 package validation
 
 import (
-	"fmt"
-	"net"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/pkg/utils"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/gardener/gardener-extension-shoot-cert-service/pkg/apis/config/validation"
 	"github.com/gardener/gardener-extension-shoot-cert-service/pkg/apis/service"
 )
 
@@ -100,7 +97,7 @@ func validateIssuers(cluster *controller.Cluster, issuers []service.IssuerConfig
 		}
 		if len(issuer.PrecheckNameservers) > 0 {
 			for j, server := range issuer.PrecheckNameservers {
-				if err := validateNameserver(server); err != nil {
+				if err := validation.ValidateNameserver(server); err != nil {
 					allErrs = append(allErrs, field.Invalid(indexFldPath.Child("precheckNameservers").Index(j), server, err.Error()))
 				}
 			}
@@ -109,26 +106,6 @@ func validateIssuers(cluster *controller.Cluster, issuers []service.IssuerConfig
 	}
 
 	return allErrs
-}
-
-func validateNameserver(server string) error {
-	host, port, err := net.SplitHostPort(server)
-	if err != nil {
-		host = server
-		port = "53"
-	}
-	if net.ParseIP(host) == nil && (len(validation.IsDNS1123Subdomain(strings.TrimSuffix(host, "."))) > 0 || len(strings.Trim(host, "0123456789.")) == 0) {
-		return fmt.Errorf("'%s' is no valid IP address or domain name", host)
-	}
-
-	n, err := strconv.Atoi(port)
-	if err != nil {
-		return fmt.Errorf("'%s' is no valid port", port)
-	}
-	if n < 1 || n > 65535 {
-		return fmt.Errorf("'%s' is no valid port number", port)
-	}
-	return nil
 }
 
 func checkReferencedResource(cluster *controller.Cluster, refname string) string {
@@ -163,11 +140,11 @@ func validatePrecheckNameservers(precheckNameservers *string, fldPath *field.Pat
 	if precheckNameservers != nil {
 		servers := strings.Split(*precheckNameservers, ",")
 		if len(servers) == 1 && len(servers[0]) == 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath, *precheckNameservers, "must contain at least one DNS server IP"))
+			allErrs = append(allErrs, field.Invalid(fldPath, *precheckNameservers, "must contain at least one DNS server address"))
 		} else {
 			for i, server := range servers {
-				if err := validateNameserver(server); err != nil {
-					allErrs = append(allErrs, field.Invalid(fldPath, *precheckNameservers, fmt.Sprintf("invalid value for %d. DNS server %s: %s", i+1, server, err.Error())))
+				if err := validation.ValidateNameserver(server); err != nil {
+					allErrs = append(allErrs, field.Invalid(fldPath.Index(i), server, err.Error()))
 				}
 			}
 		}

--- a/pkg/apis/service/validation/validation_test.go
+++ b/pkg/apis/service/validation/validation_test.go
@@ -270,15 +270,15 @@ var _ = Describe("Validation", func() {
 		}, ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("precheckNameservers"),
-				"BadValue": Equal(invalid_ns),
-				"Detail":   Equal("invalid value for 1. DNS server dns.server.te%st: 'dns.server.te%st' is no valid IP address or domain name"),
+				"Field":    Equal("precheckNameservers[0]"),
+				"BadValue": Equal("dns.server.te%st"),
+				"Detail":   ContainSubstring("'dns.server.te%st' is no valid IP address or domain name"),
 			})),
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
-				"Field":    Equal("precheckNameservers"),
-				"BadValue": Equal(invalid_ns),
-				"Detail":   Equal("invalid value for 2. DNS server dns.server.test:123456: '123456' is no valid port number"),
+				"Field":    Equal("precheckNameservers[1]"),
+				"BadValue": Equal("dns.server.test:123456"),
+				"Detail":   Equal("'123456' is no valid port number"),
 			})),
 		)),
 		Entry("Empty PrecheckNameservers", service.CertConfig{
@@ -287,7 +287,7 @@ var _ = Describe("Validation", func() {
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("precheckNameservers"),
-				"Detail": Equal("must contain at least one DNS server IP"),
+				"Detail": Equal("must contain at least one DNS server address"),
 			})),
 		)),
 	)


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Extends validation to accept FQDNs in addition to IPs, handles optional `:port` suffixes (passed through to cert-management as-is), and correctly parses bare bracketed IPv6 addresses like [::1] via `net.SplitHostPort`.

**Which issue(s) this PR fixes**:
Fixes #583 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Allow domain names in `precheckNameservers` of certificate service configuration and support `host:port` format.
```
