### PR TITLE
Enhance Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,7 @@
   extends: [
     'config:recommended',
     'github>gardener/ci-infra//config/renovate/group-go-updates.json5',
+    'github>gardener/ci-infra//config/renovate/automerge-with-tide.json5',
   ],
   dependencyDashboard: true,
   labels: [
@@ -15,12 +16,26 @@
     {
       groupName: 'gardener/gardener',
       matchPackageNames: ['/^(github\\.com\\/)?gardener\\/gardener(\\/.*)?$/'],
+      postUpgradeTasks: {
+        commands: [
+          'make tidy',
+          'make generate MODE=sequential',
+        ],
+      },
       enabled: true
     },
     {
       groupName: 'gardener/cert-management',
       matchPackageNames: ['/^(github\\.com\\/)?gardener\\/cert-management(\\/.*)?$/'],
       enabled: true
+    },
+    {
+      description: 'Automerge patch and digest updates',
+      matchUpdateTypes: [
+        'patch',
+        'digest',
+      ],
+      automerge: true,
     }
   ],
   // The following list of dependencies to ignore is updated by `make generate`.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

* Extends the Renovate config to automerge **all** kind of patch and digest update PRs ([based on our reusable config](https://github.com/gardener/ci-infra/blob/master/config/renovate/automerge-with-tide.json5)).
* Adds [postUpgradeTasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks) commands for `gardener` updates to run things like `make tidy` and `make generate` (I believe `MODE=sequential` is required in environments where GNU `parallel` is not installed).

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

@MartinWeindel, please pay special attention to the proposal to enable automerge for **any** and **all** kinds of update PRs, including patch and digest updates. This might be too aggressive.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
